### PR TITLE
Fix out-of-support issue

### DIFF
--- a/benchmark_utils/common.py
+++ b/benchmark_utils/common.py
@@ -1,5 +1,6 @@
-r""""""
+r"""Common helpers."""
 
+import pyro
 import sbibm
 import torch
 
@@ -7,6 +8,9 @@ from contextlib import contextmanager, redirect_stdout, redirect_stderr
 from io import StringIO
 from tqdm import tqdm
 from typing import Dict
+
+
+pyro.distributions.enable_validation(False)
 
 
 @contextmanager

--- a/benchmark_utils/metrics.py
+++ b/benchmark_utils/metrics.py
@@ -1,13 +1,17 @@
-r""""""
+r"""Objective and metrics."""
 
 import numpy as np
 import ot
+import pyro
 import sbibm.metrics as metrics
 import torch
 
 from torch import Tensor
 from tqdm import tqdm
 from typing import Callable, List, Tuple
+
+
+pyro.distributions.enable_validation(False)
 
 
 def negative_log_lik(

--- a/benchmark_utils/typing.py
+++ b/benchmark_utils/typing.py
@@ -1,4 +1,4 @@
-r""""""
+r"""Typing hacks."""
 
 from typing import TypeVar
 


### PR DESCRIPTION
Fix #5 by disabling validation in distributions. Doing this in `benchmark_utils` to ensure that validation is disabled after loading `pyro`.