### PR TITLE
Use the same flow architectures for lampe and sbi

### DIFF
--- a/solvers/npe_lampe.py
+++ b/solvers/npe_lampe.py
@@ -51,6 +51,7 @@ class Solver(BaseSolver):
             x.shape[-1],
             build=build,
             transforms=self.transforms,
+            hidden_features=(64, 64),
         )
 
         self.loss = lampe.inference.NPELoss(self.npe)

--- a/solvers/npe_sbi.py
+++ b/solvers/npe_sbi.py
@@ -59,7 +59,7 @@ class Solver(BaseSolver):
                 )
             elif self.flow == "nsf":
                 MAT = partial(
-                    transforms.MaskedPiecewiseRationalQuadraticAutoregressiveTransform,
+                    transforms.MaskedPiecewiseRationalQuadraticAutoregressiveTransform,  # noqa:E501
                     features=features,
                     context_features=context,
                     hidden_features=64,

--- a/solvers/npe_sbi.py
+++ b/solvers/npe_sbi.py
@@ -55,6 +55,7 @@ class Solver(BaseSolver):
                     features=features,
                     context_features=context,
                     hidden_features=64,
+                    num_blocks=2,
                     use_residual_blocks=False,
                 )
             elif self.flow == "nsf":
@@ -63,6 +64,7 @@ class Solver(BaseSolver):
                     features=features,
                     context_features=context,
                     hidden_features=64,
+                    num_blocks=2,
                     use_residual_blocks=False,
                     tails="linear",
                     tail_bound=5.0,

--- a/solvers/npe_sbi.py
+++ b/solvers/npe_sbi.py
@@ -3,8 +3,9 @@ from benchopt.stopping_criterion import SufficientProgressCriterion
 from benchmark_utils.typing import Distribution, Tensor
 
 with safe_import_context() as import_ctx:
+    from functools import partial
+    from nflows import transforms, distributions, flows
     from sbi.inference import SNPE
-    from sbi.utils.get_nn_models import posterior_nn
 
     from benchmark_utils.common import dump
 
@@ -45,22 +46,46 @@ class Solver(BaseSolver):
         self.theta, self.x, self.prior = theta, x, prior
 
     def run(self, n_iter: int):
-        estimator = posterior_nn(
-            self.flow,
-            num_transforms=self.transforms,
-            use_random_permutations=False,
-            # no z_score, data is normalized in `set_data` (objective)
-            z_score_theta="none",
-            z_score_x="none",
-        )
+        def build(theta, x):
+            features, context = theta.shape[-1], x.shape[-1]
 
-        npe = SNPE(self.prior, density_estimator=estimator)
+            if self.flow == "maf":
+                MAT = partial(
+                    transforms.MaskedAffineAutoregressiveTransform,
+                    features=features,
+                    context_features=context,
+                    hidden_features=64,
+                    use_residual_blocks=False,
+                )
+            elif self.flow == "nsf":
+                MAT = partial(
+                    transforms.MaskedPiecewiseRationalQuadraticAutoregressiveTransform,
+                    features=features,
+                    context_features=context,
+                    hidden_features=64,
+                    use_residual_blocks=False,
+                    tails="linear",
+                    tail_bound=5.0,
+                )
+
+            ts = []
+
+            for _ in range(self.transforms):
+                ts.extend([MAT(), transforms.ReversePermutation(features)])
+
+            transform = transforms.CompositeTransform(ts)
+            base = distributions.StandardNormal(shape=[features])
+
+            return flows.Flow(transform=transform, distribution=base)
+
+        npe = SNPE(self.prior, density_estimator=build)
         npe.append_simulations(self.theta, self.x)
 
         with dump():
             self.npe = npe.train(
-                validation_fraction=0.1,
+                validation_fraction=1 / len(self.theta),
                 max_num_epochs=n_iter + 1,
+                stop_after_epochs=n_iter + 1,
                 training_batch_size=128,
                 learning_rate=1e-3,
             )


### PR DESCRIPTION
This PR rewrites the flows of `npe_sbi` (using `nflows`) to match the ones of `npe_lampe`.