### PR TITLE
Solver initialization in `run()`

### DIFF
--- a/datasets/slcp.py
+++ b/datasets/slcp.py
@@ -25,7 +25,7 @@ class Dataset(BaseDataset):
     parameters = {
         "train_size": [4096, 16384],
         "test_size": [256],
-        "ref_size": [16],
+        "ref_size": [0],
         "n_per_ref": [1024],
         "seed": [42],
     }

--- a/datasets/slcp.py
+++ b/datasets/slcp.py
@@ -25,7 +25,7 @@ class Dataset(BaseDataset):
     parameters = {
         "train_size": [4096, 16384],
         "test_size": [256],
-        "ref_size": [0],
+        "ref_size": [16],
         "n_per_ref": [1024],
         "seed": [42],
     }

--- a/solvers/npe_sbi.py
+++ b/solvers/npe_sbi.py
@@ -33,9 +33,9 @@ class Solver(BaseSolver):
 
     name = "npe_sbi"
     # training is stopped if the objective value does not decrease
-    # for more than 10 iterations, no callback available
+    # for more than `patience=3` iterations, no callback available
     stopping_criterion = SufficientProgressCriterion(
-        patience=10,
+        patience=3,
     )
     # parameters that can be called with `self.<>`,
     # all possible combinations are used in the benchmark

--- a/solvers/nre_lampe.py
+++ b/solvers/nre_lampe.py
@@ -30,9 +30,9 @@ class Solver(BaseSolver):
 
     name = "nre_lampe"
     # training is stopped when the objective on the callback
-    # does not decrease for over 10 iterations.
+    # does not decrease for over `patience=3` iterations
     stopping_criterion = SufficientProgressCriterion(
-        patience=10, strategy="callback"
+        patience=3, strategy="callback"
     )
     # parameters that can be called with `self.<>`,
     # all possible combinations are used in the benchmark
@@ -54,20 +54,23 @@ class Solver(BaseSolver):
         return n_iter + 10
 
     def set_objective(self, theta: Tensor, x: Tensor, prior: Distribution):
-        r"""Initialize the solver with the given `parameters`."""
+        r"""Set the data and prior for the NRE."""
         self.theta, self.x, self.prior = theta, x, prior
 
+    def run(self, cb: Callable):
+        r"""Initialize and train the NRE."""
+        # Initialize the NRE with given `parameters`
         self.nre = lampe.inference.NRE(
             theta.shape[-1],
             x.shape[-1],
             hidden_features=(64,) * self.layers,
         )
 
+        # Initialize the loss and optimizer
         self.loss = lampe.inference.NRELoss(self.nre)
         self.optimizer = torch.optim.Adam(self.nre.parameters(), lr=1e-3)
 
-    def run(self, cb: Callable):
-        r"""Train the NRE for one iteration."""
+        # Define the training dataset
         dataset = lampe.data.JointDataset(
             self.theta,
             self.x,
@@ -75,6 +78,7 @@ class Solver(BaseSolver):
             shuffle=True,
         )
 
+        # Train the NRE
         while cb(self.get_result()):  # cb is a callback function
             for theta, x in dataset:
                 self.optimizer.zero_grad()

--- a/solvers/nre_lampe.py
+++ b/solvers/nre_lampe.py
@@ -61,8 +61,8 @@ class Solver(BaseSolver):
         r"""Initialize and train the NRE."""
         # Initialize the NRE with given `parameters`
         self.nre = lampe.inference.NRE(
-            theta.shape[-1],
-            x.shape[-1],
+            self.theta.shape[-1],
+            self.x.shape[-1],
             hidden_features=(64,) * self.layers,
         )
 


### PR DESCRIPTION
If the initialization is outside of `run()`, the solver is not re-initialized between repetitions. As soon as `n-repetitions` is larger than 1, the objective curves become "flat".